### PR TITLE
feat: Loss-based sampling (sample-then-batch only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ We evaluate data selection methods on a range of tuning tasks.
 
 ```bash
 # Create the 'selection' conda environment
-conda env create -n conda.yaml
+conda env create -f conda.yaml
 conda activate selection
 
 # Now set the HF_TOKEN environment variable in your conda environment

--- a/misc/collate.py
+++ b/misc/collate.py
@@ -1,0 +1,12 @@
+from typing import Any
+import torch
+
+def collate_with_sample_id(batch: list[dict[str, Any]], base_collate_fn, **kwargs) -> dict[str, Any]:
+    """
+    Calls the base collate function, then adds a 'sample_ids' field.
+    """
+    collated = base_collate_fn(batch, **kwargs)
+    assert "sample_id" in batch[0]
+    sample_ids = [sample["sample_id"] for sample in batch]
+    collated["sample_ids"] = torch.tensor(sample_ids, dtype=torch.long)
+    return collated

--- a/misc/indexed_ds.py
+++ b/misc/indexed_ds.py
@@ -1,6 +1,8 @@
 from torch.utils.data import Dataset
 
 class IndexedWrapperDataset(Dataset):
+    """Generic dataset wrapper that adds sample indices to the items."""
+
     def __init__(self, dataset: Dataset):
         self.dataset = dataset
 

--- a/misc/indexed_ds.py
+++ b/misc/indexed_ds.py
@@ -1,0 +1,24 @@
+from torch.utils.data import Dataset
+
+class IndexedWrapperDataset(Dataset):
+    def __init__(self, dataset: Dataset):
+        self.dataset = dataset
+
+    def __getitem__(self, index):
+        item = self.dataset[index]
+        assert isinstance(item, dict)
+        assert "sample_id" not in item or item["sample_id"] == index
+        item['sample_id'] = index
+        return item
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getattr__(self, attr):
+        """
+        Forward any attribute or method access not defined here to the underlying dataset.
+        This includes any additional method calls.
+        """
+        if attr == "dataset": # Prevent recursive call when dataset attribute isn't yet set
+            raise AttributeError("Attribute 'dataset' is not defined.")
+        return getattr(self.dataset, attr)

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -666,15 +666,14 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             logits: Tensor of shape [B, seq_len, vocab_size]
             shifted_labels: Tensor of shape [B, seq_len] (for scoring)
         """
-        log.info(f"batch keys 1: {batch.keys()}")
         labels = batch.pop("labels")
-        log.info(f"batch keys 2: {batch.keys()}")
+        sample_ids = batch.pop("sample_ids")
         with self.activations_handling_ctx:
-            log.info(f"batch keys 3: {batch.keys()}")
             logits = self._model(**batch)
         batch_size = labels.size(0)
         shifted_labels = torch.hstack((labels[..., 1:], self.ignore_labels_cache[:batch_size]))
         batch["labels"] = labels  # restore
+        batch["sample_ids"] = sample_ids
         return logits, shifted_labels
 
     def train(self) -> None:

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -701,11 +701,12 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             # in case shuffle is True
             self._sampler.set_epoch(curr_epoch)
 
-            pbar = tqdm(total=self._steps_per_epoch)
             self._sampler.pre_epoch()
             # ----- First Pass: Scoring Phase -----
             utils.get_logger("DEBUG").info("Starting scoring pass for epoch %d", curr_epoch)
+            pbar = tqdm(desc="Scoring", total=self._steps_per_epoch)
             for idx, batch in enumerate(self._dataloader):
+                pbar.update(1)
                 utils.batch_to_device(batch, self._device)
                 # TODO: optionally disable grad to speed this up.
                 logits, shifted_labels = self._forward_pass(batch)
@@ -716,6 +717,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             utils.get_logger("DEBUG").info("Scoring complete; selected %d samples", self._sampler.mask.sum().item())
 
             # ----- Second pass: Training phase (uses updated sampler mask) -----
+            pbar = tqdm(desc="Training", total=self._steps_per_epoch)
             for idx, batch in enumerate(self._dataloader):
                 if (
                     self.max_steps_per_epoch is not None

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -706,7 +706,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             for idx, batch in enumerate(self._dataloader):
                 utils.batch_to_device(batch, self._device)
                 # TODO: optionally disable grad to speed this up.
-                logits, shifted_labels = self._forward_pass(batch)
+                logits, shifted_labels = self._forward_pass(batch.pop("sample_ids", None))
                 sample_ids = batch["sample_ids"].tolist()
                 self._sampler.inform_logits(sample_ids, logits, shifted_labels)
 

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -666,8 +666,11 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             logits: Tensor of shape [B, seq_len, vocab_size]
             shifted_labels: Tensor of shape [B, seq_len] (for scoring)
         """
+        log.info(f"batch keys 1: {batch.keys()}")
         labels = batch.pop("labels")
+        log.info(f"batch keys 2: {batch.keys()}")
         with self.activations_handling_ctx:
+            log.info(f"batch keys 3: {batch.keys()}")
             logits = self._model(**batch)
         batch_size = labels.size(0)
         shifted_labels = torch.hstack((labels[..., 1:], self.ignore_labels_cache[:batch_size]))
@@ -706,7 +709,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
             for idx, batch in enumerate(self._dataloader):
                 utils.batch_to_device(batch, self._device)
                 # TODO: optionally disable grad to speed this up.
-                logits, shifted_labels = self._forward_pass(batch.pop("sample_ids", None))
+                logits, shifted_labels = self._forward_pass(batch)
                 sample_ids = batch["sample_ids"].tolist()
                 self._sampler.inform_logits(sample_ids, logits, shifted_labels)
 

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -722,7 +722,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
 
             self._sampler.sample()
             self._set_steps_per_epoch()
-            utils.get_logger("DEBUG").info("Scoring complete; selected %d samples", self._sampler.mask.sum().item())
+            utils.get_logger("DEBUG").info("Scoring complete; selected %d samples", sum(self._sampler.mask))
 
             # ----- Second pass: Training phase (uses updated sampler mask) -----
             pbar = tqdm(desc="Training", total=self._steps_per_epoch)

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -638,6 +638,7 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
     def _loss_step(self, batch: Dict[str, torch.Tensor]) -> torch.Tensor:
         # Shape [b, s], needed for the loss not the model
         labels = batch.pop("labels")
+        sample_ids = batch.pop("sample_ids")
 
         with self.activations_handling_ctx:
             logits = self._model(**batch)

--- a/selection/fullsampler.py
+++ b/selection/fullsampler.py
@@ -4,10 +4,6 @@ from selection.selectivesampler import SelectiveSampler
 class FullSampler(SelectiveSampler):
     """Example implementation of SelectiveSampler that uses all of the samples."""
 
-    def set_num_selected_samples(self):
-        """Set expected number of selected samples for dataset len"""
-        self._num_selected_samples = self.num_samples
-
     def pre_epoch(self) -> None:
         """Set mask to select all samples before each epoch starts"""
         n = len(self.dataset)

--- a/selection/halfsampler.py
+++ b/selection/halfsampler.py
@@ -10,10 +10,6 @@ class HalfSampler(SelectiveSampler):
     2. Implementing required hook methods with simple pass-through behavior
     """
 
-    def set_num_selected_samples(self):
-        """Set expected number of selected samples for dataset len"""
-        self._num_selected_samples = self.num_samples // 2
-
     def pre_epoch(self) -> None:
         """Set mask to select first half of samples before each epoch starts"""
         n = len(self.dataset)

--- a/selection/halfsampler.py
+++ b/selection/halfsampler.py
@@ -1,3 +1,4 @@
+import torch
 from selection.selectivesampler import SelectiveSampler
 
 
@@ -30,4 +31,10 @@ class HalfSampler(SelectiveSampler):
 
     def after_forward(self, idx: int, batch: dict, current_loss: float) -> None:
         """No-op after forward hook"""
+        pass
+
+    def inform_logits(self, sample_ids: list[int], logits: torch.Tensor, shifted_labels: torch.Tensor) -> None:
+        pass
+
+    def sample(self) -> None:
         pass

--- a/selection/loss_sampler.py
+++ b/selection/loss_sampler.py
@@ -35,8 +35,10 @@ class LossBasedSampler(SelectiveSampler):
     def pre_epoch(self) -> None:
         # Reset the loss buffer and mask at the start of each epoch.
         self._loss_buffer = {}
-        self.mask = None
-    
+        n = len(self.dataset)
+        mask = [True] * n
+        self.set_mask(mask)
+
     def post_epoch(self) -> None:
         pass
 

--- a/selection/loss_sampler.py
+++ b/selection/loss_sampler.py
@@ -1,0 +1,99 @@
+import copy
+import torch
+from selection.selectivesampler import SelectiveSampler
+
+
+class LossBasedSampler(SelectiveSampler):
+    """
+    The LossBasedSampler maintains an internal loss buffer and, at the end of the scoring pass,
+    computes per-sample selection probabilities and updates its internal mask.
+    A copy of the loss_fn is used (with reduction='none') so that the regular
+    training loss function is unaffected.
+    """
+    def __init__(
+        self,
+        dataset,
+        loss_fn: torch.nn.Module,
+        num_replicas=None,
+        rank=None,
+        shuffle=True,
+        seed=0,
+        sampling_ratio: float = 0.5,
+    ):
+        super().__init__(dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed)
+        self._per_sample_loss_fn = copy.deepcopy(loss_fn)
+        if hasattr(self._per_sample_loss_fn, "reduction"):
+            self._per_sample_loss_fn.reduction = "none"
+        self.sampling_ratio = sampling_ratio
+        # loss_buffer is a dict mapping dataset index -> accumulated loss and token count.
+        self._loss_buffer = {}  # {sample_id: (loss_sum, valid_tokens)}
+        self.mask = None  # Boolean tensor of size len(dataset)
+    
+    def set_num_selected_samples(self) -> None:
+        self._num_selected_samples = len(self.dataset)
+    
+    def pre_epoch(self) -> None:
+        # Reset the loss buffer and mask at the start of each epoch.
+        self._loss_buffer = {}
+        self.mask = None
+    
+    def post_epoch(self) -> None:
+        pass
+
+    def on_batch(self, idx: int, batch: dict) -> None:
+        # No action here; we use inform_logits() for scoring.
+        pass
+
+    def after_forward(self, idx: int, batch: dict, current_loss: float) -> None:
+        pass
+
+    def inform_logits(self, sample_ids: list[int], logits: torch.Tensor, shifted_labels: torch.Tensor) -> None:
+        """
+        For each sample in the batch compute its per-token losses and aggregate.
+        If a sample occurs in multiple sequences, accumulate loss_sum and token_count.
+        logits: [B, seq_len, vocab_size]
+        shifted_labels: [B, seq_len]
+        """
+        token_losses = self._per_sample_loss_fn(logits, shifted_labels).detach()  # [B, seq_len]
+        valid_mask = (shifted_labels != self._per_sample_loss_fn.ignore_index).float()  # [B, seq_len]
+        loss_sum_batch = (token_losses * valid_mask).sum(dim=1)  # [B]
+        token_count_batch = valid_mask.sum(dim=1) + 1e-6  # [B] (avoids divison by zero)
+        # For each sample in the batch, update or initialize the aggregation.
+        for sid, loss_val, count in zip(sample_ids, loss_sum_batch.tolist(), token_count_batch.tolist()):
+            if sid in self._loss_buffer:
+                prev_loss, prev_count = self._loss_buffer[sid]
+                self._loss_buffer[sid] = (prev_loss + loss_val, prev_count + count)
+            else:
+                self._loss_buffer[sid] = (loss_val, count)
+
+    def sample(self) -> None:
+        """
+        After the scoring pass, compute average loss per sample for all samples in _loss_buffer,
+        compute selection probabilities, and update self.mask (Boolean tensor over dataset).
+        """
+        if len(self._loss_buffer) == 0:
+            print("No samples informed; selecting all samples.")
+            self.mask = torch.ones(len(self.dataset), dtype=torch.bool)
+            return
+
+        # Compute average loss for each scored sample.
+        all_sample_ids = list(self._loss_buffer.keys())
+        avg_losses = []
+        for sid in all_sample_ids:
+            loss_sum, token_count = self._loss_buffer[sid]
+            avg_losses.append(loss_sum / token_count)
+        losses = torch.tensor(avg_losses, dtype=torch.float)
+        eps = 1e-6
+        probs = losses + eps
+        probs = probs / probs.sum()
+        
+        num_scored = len(all_sample_ids)
+        num_select = max(1, int(self.sampling_ratio * num_scored))
+        selected_idxs_in_scored = torch.multinomial(probs, num_select, replacement=False)
+        selected_sample_ids = set(all_sample_ids[i] for i in selected_idxs_in_scored.tolist())
+
+        mask = torch.zeros(len(self.dataset), dtype=torch.bool)
+        for sid in range(len(self.dataset)):
+            if sid in selected_sample_ids:
+                mask[sid] = True
+        self.mask = mask

--- a/selection/loss_sampler.py
+++ b/selection/loss_sampler.py
@@ -28,6 +28,7 @@ class LossBasedSampler(SelectiveSampler):
         # loss_buffer is a dict mapping dataset index -> accumulated loss and token count.
         self._loss_buffer = {}  # {sample_id: (loss_sum, valid_tokens)}
         self.mask = None  # Boolean tensor of size len(dataset)
+        self.no_grad_scoring = True
     
     def set_num_selected_samples(self) -> None:
         self._num_selected_samples = len(self.dataset)

--- a/selection/loss_sampler.py
+++ b/selection/loss_sampler.py
@@ -79,6 +79,8 @@ class LossBasedSampler(SelectiveSampler):
             self.mask = torch.ones(len(self.dataset), dtype=torch.bool)
             return
 
+        print(f"Saw {len(self._loss_buffer.keys())} sample IDs in total.")
+
         # Compute average loss for each scored sample.
         all_sample_ids = list(self._loss_buffer.keys())
         avg_losses = []
@@ -92,6 +94,9 @@ class LossBasedSampler(SelectiveSampler):
         
         num_scored = len(all_sample_ids)
         num_select = max(1, int(self.sampling_ratio * num_scored))
+
+        print(f"num_scored = {num_scored}, num_select = {num_select}, mask sum = {self.mask.sum()}")
+
         selected_idxs_in_scored = torch.multinomial(probs, num_select, replacement=False)
         selected_sample_ids = set(all_sample_ids[i] for i in selected_idxs_in_scored.tolist())
 
@@ -100,3 +105,5 @@ class LossBasedSampler(SelectiveSampler):
             if sid in selected_sample_ids:
                 mask[sid] = True
         self.mask = mask
+
+        print(f"new mask sum = {self.mask.sum()}")

--- a/selection/loss_sampler.py
+++ b/selection/loss_sampler.py
@@ -95,15 +95,12 @@ class LossBasedSampler(SelectiveSampler):
         num_scored = len(all_sample_ids)
         num_select = max(1, int(self.sampling_ratio * num_scored))
 
-        print(f"num_scored = {num_scored}, num_select = {num_select}, mask sum = {self.mask.sum()}")
+        print(f"num_scored = {num_scored}, num_select = {num_select}, mask sum = {sum(self.mask)}")
 
         selected_idxs_in_scored = torch.multinomial(probs, num_select, replacement=False)
         selected_sample_ids = set(all_sample_ids[i] for i in selected_idxs_in_scored.tolist())
 
-        mask = torch.zeros(len(self.dataset), dtype=torch.bool)
-        for sid in range(len(self.dataset)):
-            if sid in selected_sample_ids:
-                mask[sid] = True
-        self.mask = mask
-
-        print(f"new mask sum = {self.mask.sum()}")
+        mask = [sid in selected_sample_ids for sid in range(len(self.dataset))]
+        self.set_mask(mask)
+        
+        print(f"new mask sum = {sum(self.mask)}")

--- a/selection/selectivesampler.py
+++ b/selection/selectivesampler.py
@@ -29,7 +29,6 @@ class SelectiveSampler(DistributedSampler, ABC):
             dataset, num_replicas=num_replicas, rank=rank, shuffle=shuffle, seed=seed
         )
         self.mask = None
-        self.set_num_selected_samples()
         self.no_grad_scoring = False
 
     def set_mask(self, mask):

--- a/selection/selectivesampler.py
+++ b/selection/selectivesampler.py
@@ -51,14 +51,9 @@ class SelectiveSampler(DistributedSampler, ABC):
         return iter(indices)
 
     def __len__(self) -> int:
-        return self._num_selected_samples
-
-    @abstractmethod
-    def set_num_selected_samples(self) -> None:
-        """Hook called on initialisation. Set expected number of selected samples for dataset len.
-        Temporary workaround for __len__ method to return correct value. Must be implemented by subclasses
-        """
-        pass
+        if self.mask is not None:
+            return sum(self.mask)
+        return len(self.dataset)
 
     @abstractmethod
     def pre_epoch(self) -> None:

--- a/selection/selectivesampler.py
+++ b/selection/selectivesampler.py
@@ -30,6 +30,7 @@ class SelectiveSampler(DistributedSampler, ABC):
         )
         self.mask = None
         self.set_num_selected_samples()
+        self.no_grad_scoring = False
 
     def set_mask(self, mask):
         """Set a boolean mask to filter samples"""

--- a/selection/selectivesampler.py
+++ b/selection/selectivesampler.py
@@ -89,3 +89,20 @@ class SelectiveSampler(DistributedSampler, ABC):
             current_loss (float): The loss value from the current forward pass
         """
         pass
+
+    @abstractmethod
+    def inform_logits(self, idx: int, batch: dict, current_loss: float) -> None:
+        """Hook called after model forward pass. Must be implemented by subclasses.
+
+        Args:
+            idx (int): The index/step number of the current batch
+            batch (dict): The batch data dictionary containing inputs and labels
+            current_loss (float): The loss value from the current forward pass
+        """
+        pass
+
+    @abstractmethod
+    def sample(self) -> None:
+        """Called after first phase forward pass in sample-then-batch
+        """
+        pass


### PR DESCRIPTION
This adds a first implementation of sample-then-batch loss-based sampling. Critical follow up tasks are:

- Clean up the interface of the SelectiveSampler. There are many hooks which might not be needed, and some even conflict ("after batch" without the proper actually needed information).
- Generalize the full_finetune recipe to support both sample-then-batch OR batch-then-sample using the same selective sampler. Right now we hardcode sample-then-batch.


I also touch on the `set_num_selected_samples` stuff because it kept giving me trouble and I did not see why it was necessary to do it like that instead of based on the mask.