### PR TITLE
Added Option for RadT_set_experiment and Stdout Flushing When Training Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,15 @@ tune cp $model_config $config_path --make-parents
 You can finetune Llama3.2 1B on a single GPU using the following command (with/without radT):
 
 ```bash
-python -u tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
-python -u -m radt --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
+python tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
+python -m radt --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
 ```
  
 Or with LoRA:
  
 ```bash
-python -u tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
-python -u -m radt --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
+python tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
+python -m radt --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
 ```
 
 Saving with RadT with a specific MLflow experiment ID
@@ -111,12 +111,12 @@ Saving with RadT with a specific MLflow experiment ID
 # set experiment_id to the MLflow experiment ID 
 experiment_id=" " 
 # full model 
-python -u -m radt -e $experiment_id --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
+python -m radt -e $experiment_id --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
 ```
 
 ```bash
 # With lora model
-python -u -m radt -e $experiment_id --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_full/train.yaml
+python -m radt -e $experiment_id --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_full/train.yaml
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -94,16 +94,31 @@ tune cp $model_config $config_path --make-parents
 You can finetune Llama3.2 1B on a single GPU using the following command (with/without radT):
 
 ```bash
-python tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
-python -m radt --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
+python -u tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
+python -u -m radt --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
+```
+ 
+Or with LoRA:
+ 
+```bash
+python -u tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
+python -u -m radt --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
 ```
 
-Or with LoRA:
+Saving with RadT with a specific MLflow experiment ID
 
 ```bash
-python tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
-python -m radt --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_lora/train.yaml
+# set experiment_id to the MLflow experiment ID 
+experiment_id=" " 
+# full model 
+python -u -m radt -e $experiment_id --local --manual tune.py run recipe/full_finetune.py --config config/llama3_2/1b_full/train.yaml
 ```
+
+```bash
+# With lora model
+python -u -m radt -e $experiment_id --local --manual tune.py run recipe/lora_finetune.py --config config/llama3_2/1b_full/train.yaml
+```
+
 
 &nbsp;
 

--- a/recipe/full_finetune.py
+++ b/recipe/full_finetune.py
@@ -698,6 +698,8 @@ class FullFinetuneRecipeSingleDevice(FTRecipeInterface):
         self._profiler.start()
         
         with radt.run.RADTBenchmark() as run:
+            # log sampler type to ML-flow experiment via radT 
+            run.log_param("sampler_type", type(self._sampler).__name__)
             # self.epochs_run should be non-zero when we're resuming from a checkpoint
             for curr_epoch in range(self.epochs_run, self.total_epochs):
                 # Update the sampler to ensure data is correctly shuffled across epochs


### PR DESCRIPTION
#### **Summary**  
Introduces an option to specify an MLflow experiment when using RadT for finetuning, along with improved stdout flushing for better logging during model training.  

#### **Changes Made**  
1. **Updated `README.md`**  
   - Added instructions for setting an MLflow experiment ID when using RadT.  
   - Provided examples for finetuning with and without RadT, including full model and LoRA-based training.  

2. **Modified `full_finetune.py`**  
   - Added logging of the sampler type to MLflow via RadT using:  
     ```python
     run.log_param("sampler_type", type(self._sampler).__name__)
     ```  

3. **Improved Stdout Flushing**  
   - Ensured proper flushing of stdout during training runs to prevent log delays.  
