### PR TITLE
Fix SelectiveSampler.__iter__() indices bug selecting idx instead of i

### DIFF
--- a/selection/selectivesampler.py
+++ b/selection/selectivesampler.py
@@ -43,7 +43,8 @@ class SelectiveSampler(DistributedSampler, ABC):
         if self.mask is None:
             raise RuntimeError("No mask set - call set_mask() before iterating")
 
-        indices = [idx for i, idx in enumerate(indices) if self.mask[idx]]
+        indices = [idx for i, idx in enumerate(indices) if self.mask[i]]
+        
         if not indices:
             raise RuntimeError("No samples selected - mask may be all False or unset")
 


### PR DESCRIPTION
### Summary  
This PR fixes a bug in `SelectiveSampler.__iter__()` where indices were incorrectly selected. Instead of using `i`, the loop mistakenly used `idx`, leading to incorrect filtering when applying the mask.  


### Changes  
- Fixed list comprehension in `__iter__()` to properly filter using `i` instead of `idx`. 

### Impact  
- Ensures `SelectiveSampler` correctly filters indices based on the mask.  
- Makes subclass Samplers (HalfSampler, FullSampler etc) correctly select shuffled dataset indices and not mask indices where "True" value is present. 

